### PR TITLE
Trailing newline fix + other minor stuff

### DIFF
--- a/lib/stomp/connection.rb
+++ b/lib/stomp/connection.rb
@@ -390,7 +390,7 @@ module Stomp
             message_header = ''
             line = ''
             begin
-              message_header += line
+              message_header << line
               line = read_socket.gets
               return nil if line.nil?
             end until line =~ /^\s?\n$/
@@ -406,7 +406,7 @@ module Stomp
               raise Stomp::Error::InvalidMessageLength unless parse_char(read_socket.getc) == "\0"
             # Else reads, the rest of the message until the first \0
             else
-              message_body += char while (char = parse_char(read_socket.getc)) != "\0"
+              message_body << char while (char = parse_char(read_socket.getc)) != "\0"
             end
 
             # Adds the excluded \n and \0 and tries to create a new message with it


### PR DESCRIPTION
The jruby workaround for handling trailing newlines didn't work for me.  I kept getting timeouts.  (The timeouts also seem to have issues under jruby but that doesn't matter for this pull request.)  Looking at the code, using read_socket.ready? to drain trailing newlines looked race-prone and wacky even when it "worked" with MRI.  I switched things up to treat trailing newlines from one message as preceding newlines on the next message.  I've tested with 1.8.7 and jruby in 1.8 and 1.9 modes.

Another commit handles eof while reading the headers.

The third uses << instead of += when concatenating strings from the server.  No need to create a new object every time, and avoid O(n^2) when no content-length is given.
