### PR TITLE
Minor fix to Stomp::Client.find_listener

### DIFF
--- a/lib/stomp/client.rb
+++ b/lib/stomp/client.rb
@@ -314,7 +314,7 @@ module Stomp
           # For backward compatibility, some messages may already exist with no
           # subscription id, in which case we can attempt to synthesize one.
           set_subscription_id_if_missing(message.headers['destination'], message.headers)
-          subscription_id = message.headers['id']
+          subscription_id = message.headers[:id]
         end
         @listeners[subscription_id]
       end


### PR DESCRIPTION
`set_subscription_id_if_missing` sets `headers[:id]`, so `find_listener` should use this instead of `headers['id']`.
