### PR TITLE
Always log connection attempts via on_connecting

### DIFF
--- a/lib/stomp/connection.rb
+++ b/lib/stomp/connection.rb
@@ -663,10 +663,6 @@ module Stomp
         #
       	ssl = nil
 
-        if @logger && @logger.respond_to?(:on_connecting)
-          @logger.on_connecting(log_params)
-        end
-
       	Timeout::timeout(@connect_timeout, Stomp::Error::SocketOpenTimeout) do
         	ssl = OpenSSL::SSL::SSLSocket.new(open_tcp_socket, ctx)
       	end


### PR DESCRIPTION
Prior to this commit the on_connect logger would only be called on
initialize, not later on during reconnects such as those initiated
during managing a reliable connection:

```
`on_connecting' Connection attempt 0 to stomp://rip@stomp:6162
`on_connectfail' Connection to stomp://rip@stomp:6162 failed on attempt 0
`on_connected' Conncted to stomp://rip@stomp:6163
```

Here a 2nd connection attempt was made to the failover connection that
was defined in the pool but never logged

With this commit we now log at each attempt to reconnect the sockets
instead so we get:

```
`on_connecting' Connection attempt 0 to stomp://rip@stomp:6162
`on_connectfail' Connection to stomp://rip@stomp:6162 failed on attempt 0
`on_connecting' Connection attempt 1 to stomp://rip@stomp:6163
`on_connected' Conncted to stomp://rip@stomp:6163
```
