### PR TITLE
Default to version 1.1 if none is returned by the server

### DIFF
--- a/lib/stomp/connection.rb
+++ b/lib/stomp/connection.rb
@@ -843,7 +843,7 @@ module Stomp
         return unless (@connect_headers[:"accept-version"] && @connect_headers[:host])
         return if @connection_frame.command == Stomp::CMD_ERROR
         cfh = @connection_frame.headers.symbolize_keys
-        @protocol = cfh[:version]
+        @protocol = cfh[:version] || "1.1" # default to 1.1 in case no version is present (HornetQ)
         # Should not happen, but check anyway
         raise Stomp::Error::UnsupportedProtocolError unless Stomp::SUPPORTED.index(@protocol)
         # Heartbeats


### PR DESCRIPTION
HornetQ's stomp implementation does not return the "version" header, this hack ensures the @protocol instance variable is always set to something that makes sense and allows the gem to work with HornetQ. I already opened a bug with them but in the meantime this should solve the issue.

https://issues.jboss.org/browse/HORNETQ-923
