### PR TITLE
Explicitly flushing the connection to prevent last message chunk from not being sent

### DIFF
--- a/lib/stomp/client.rb
+++ b/lib/stomp/client.rb
@@ -35,7 +35,7 @@ module Stomp
     #   stomp://login:passcode@host:port
     #   stomp://login:passcode@host.domain.tld:port
     #
-    def initialize(login = '', passcode = '', host = 'localhost', port = 61613, reliable = false)
+    def initialize(login = '', passcode = '', host = 'localhost', port = 61613, reliable = false, autoflush = false)
 
       # Parse stomp:// URL's or set params
       if login.is_a?(Hash)
@@ -49,7 +49,6 @@ module Stomp
         @port = first_host[:port] || Connection::default_port(first_host[:ssl])
         
         @reliable = true
-        
       elsif login =~ /^stomp:\/\/#{url_regex}/ # e.g. stomp://login:passcode@host:port or stomp://host:port
         @login = $2 || ""
         @passcode = $3 || ""
@@ -94,6 +93,7 @@ module Stomp
         @connection = Connection.new(@parameters)
       else
         @connection = Connection.new(@login, @passcode, @host, @port, @reliable)
+        @connection.autoflush = autoflush
       end
       
       start_listeners
@@ -269,6 +269,14 @@ module Stomp
     # Return nil of no message available, else the message
     def poll
       @connection.poll
+    end
+
+    def autoflush=(af)
+      @connection.autoflush = af
+    end
+
+    def autoflush
+      @connection.autoflush
     end
 
     private

--- a/lib/stomp/connection.rb
+++ b/lib/stomp/connection.rb
@@ -10,12 +10,13 @@ module Stomp
   # Low level connection which maps commands and supports
   # synchronous receives
   class Connection
-    attr_reader :connection_frame
-    attr_reader :disconnect_receipt
-    attr_reader :protocol
-    attr_reader :session
-    attr_reader :hb_received # Heartbeat received on time
-    attr_reader :hb_sent # Heartbeat sent successfully
+    attr_reader   :connection_frame
+    attr_reader   :disconnect_receipt
+    attr_reader   :protocol
+    attr_reader   :session
+    attr_reader   :hb_received # Heartbeat received on time
+    attr_reader   :hb_sent # Heartbeat sent successfully
+    attr_accessor :autoflush
     #alias :obj_send :send
 
     def self.default_port(ssl)
@@ -87,6 +88,7 @@ module Stomp
         @parse_timeout = 5		# To override, use hashed parameters
         @connect_timeout = 0	# To override, use hashed parameters
         @logger = nil     		# To override, use hashed parameters
+        @autoflush = false    # To override, use hashed parameters or setter
         warn "login looks like a URL, do you have the correct parameters?" if @login =~ /:\/\//
       end
 
@@ -112,6 +114,7 @@ module Stomp
       @parse_timeout =  @parameters[:parse_timeout]
       @connect_timeout =  @parameters[:connect_timeout]
       @logger =  @parameters[:logger]
+      @autoflush = @parameters[:autoflush]
       #sets the first host to connect
       change_host
     end
@@ -638,7 +641,7 @@ module Stomp
           used_socket.puts
           used_socket.write body
           used_socket.write "\0"
-          used_socket.flush
+          used_socket.flush if autoflush
 
           if @protocol >= Stomp::SPL_11
             @ls = Time.now.to_f if @hbs

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -7,7 +7,7 @@ require 'client_shared_examples'
 describe Stomp::Client do
 
   before(:each) do
-    @mock_connection = mock('connection')
+    @mock_connection = mock('connection', :autoflush= => true)
     Stomp::Connection.stub!(:new).and_return(@mock_connection)
   end
 
@@ -31,6 +31,23 @@ describe Stomp::Client do
 
     it_should_behave_like "standard Client"
 
+  end
+
+  describe "(autoflush)" do
+    it "should delegate to the connection for accessing the autoflush property" do
+      @mock_connection.should_receive(:autoflush)
+      Stomp::Client.new.autoflush
+    end
+
+    it "should delegate to the connection for setting the autoflush property" do
+      @mock_connection.should_receive(:autoflush=).with(true)
+      Stomp::Client.new.autoflush = true
+    end
+
+    it "should set the autoflush property on the connection when passing in autoflush as a parameter to the Stomp::Client" do
+      @mock_connection.should_receive(:autoflush=).with(true)
+      Stomp::Client.new("login", "password", 'localhost', 61613, false, true)
+    end
   end
 
   describe "(created with invalid params)" do

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -21,7 +21,7 @@ describe Stomp::Connection do
       :connect_timeout => 0,
       :parse_timeout => 5,
       :connect_headers => {},
-      :dmh => false,
+      :dmh => false
     }
         
     #POG:
@@ -36,6 +36,39 @@ describe Stomp::Connection do
     @tcp_socket = mock(:tcp_socket, :close => nil, :puts => nil, :write => nil, :setsockopt => nil, :flush => true)
     TCPSocket.stub!(:open).and_return @tcp_socket
     @connection = Stomp::Connection.new(normal_parameters)
+  end
+
+  describe "autoflush" do
+    let(:parameter_hash) {
+      {
+        "hosts" => [
+          {:login => "login2", :passcode => "passcode2", :host => "remotehost", :port => 61617, :ssl => false},
+          {:login => "login1", :passcode => "passcode1", :host => "localhost", :port => 61616, :ssl => false}
+        ],
+        "reliable" => true,
+        "initialReconnectDelay" => 0.01,
+        "maxReconnectDelay" => 30.0,
+        "useExponentialBackOff" => true,
+        "backOffMultiplier" => 2,
+        "maxReconnectAttempts" => 0,
+        "randomize" => false,
+        "backup" => false,
+        "connect_timeout" => 0,
+        "parse_timeout" => 5,
+      }
+    }
+
+    it "should call flush on the socket when autoflush is true" do
+      @tcp_socket.should_receive(:flush)
+      @connection = Stomp::Connection.new(parameter_hash.merge("autoflush" => true))
+      @connection.publish "/queue", "message", :suppress_content_length => false
+    end
+
+    it "should not call flush on the socket when autoflush is false" do
+      @tcp_socket.should_not_receive(:flush)
+      @connection = Stomp::Connection.new(parameter_hash)
+      @connection.publish "/queue", "message", :suppress_content_length => false
+    end    
   end
   
   describe "(created using a hash)" do
@@ -54,7 +87,7 @@ describe Stomp::Connection do
         "randomize" => false,
         "backup" => false,
         "connect_timeout" => 0,
-        "parse_timeout" => 5,
+        "parse_timeout" => 5
       }
       
       @connection = Stomp::Connection.new(used_hash)


### PR DESCRIPTION
Had an issue where sending even a small volume of messages would result in occasionally losing last chunk of the message being sent from the stomp client to the ActiveMQ server (explicitly last chunk of XML string was not sent, resulting in malformed XML).  Ran tests with 25k messages and was able to reproduce the issue.  Adding explicit flush call to the socket solved the problem over the same 25k messages.
