### PR TITLE
Expose SSLContext#ssl_protocol as SSLParams#protocol

### DIFF
--- a/lib/connection/netio.rb
+++ b/lib/connection/netio.rb
@@ -267,6 +267,10 @@ module Stomp
             ctx.key  = OpenSSL::PKey::RSA.new(File.read(@ssl.key_file), @ssl.key_password)
           end
 
+          if @ssl.protocol # User supplied a protocol
+            ctx.ssl_protocol = @ssl.protocol
+          end
+
           # Cipher list
           if !@ssl.use_ruby_ciphers # No Ruby ciphers (the default)
             if @ssl.ciphers # User ciphers list?

--- a/lib/stomp/sslparams.rb
+++ b/lib/stomp/sslparams.rb
@@ -28,6 +28,10 @@ module Stomp
   # the handshake.
   attr_accessor :peer_cert
 
+  # Optional specification of SSL protocol to use.  Must be one of
+  # OpenSSL::SSL::SSLContext::METHODS
+  attr_accessor :protocol
+
   # Optional list of SSL ciphers to be used.  In the format documented for
   # Ruby's OpenSSL.
   attr_accessor :ciphers
@@ -56,6 +60,7 @@ module Stomp
    raise Stomp::Error::SSLClientParamsError if @cert_file.nil? && !@key_file.nil?
    raise Stomp::Error::SSLClientParamsError if !@cert_file.nil? && @key_file.nil?
    #
+   @protocol = opts[:protocol]
    @ciphers = opts[:ciphers]
    @use_ruby_ciphers = opts[:use_ruby_ciphers] ? opts[:use_ruby_ciphers] : false
    #


### PR DESCRIPTION
With this commit we allow the choice of ssl protocol to be specified by the
user.  This allows for mitigation of protocol-based attacks such as the current
SSLv3 POODLE by specifying SSLParams.new(:protocol => :TLSv1_2, ...)
