### PR TITLE
Strip possible newline from beginning of frame

### DIFF
--- a/lib/connection/netio.rb
+++ b/lib/connection/netio.rb
@@ -31,6 +31,8 @@ module Stomp
         end
         #
         return nil if line.nil?
+        #An extra \n at the beginning of the 
+        line = '' if line = "\n"
         # p [ "wiredatain_01", line ]
         line = _normalize_line_end(line) if @protocol >= Stomp::SPL_12
         # If the reading hangs for more than X seconds, abort the parsing process.

--- a/lib/connection/netio.rb
+++ b/lib/connection/netio.rb
@@ -31,8 +31,8 @@ module Stomp
         end
         #
         return nil if line.nil?
-        #An extra \n at the beginning of the 
-        line = '' if line = "\n"
+        #An extra \n at the beginning of the frame, possibly not caught by is_ready?
+        line = '' if line == "\n"
         # p [ "wiredatain_01", line ]
         line = _normalize_line_end(line) if @protocol >= Stomp::SPL_12
         # If the reading hangs for more than X seconds, abort the parsing process.


### PR DESCRIPTION
We have seen a number of messages fail due to an errant \n at the beginning of the frame.  This causes the frame command to be invalid, though the message is legitimate.

We believe there is a race condition occurring where AMQ is adding the additional \n after the \0 at the end of the previous frame, but that the is_ready? check at the end of a frame read is just missing it.