### PR TITLE
Lock dependency to RSpec 2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# encoding: utf-8
+
+source "https://rubygems.org"
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,27 @@
+PATH
+  remote: .
+  specs:
+    stomp (1.3.4)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.5)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.8)
+    rspec-expectations (2.14.5)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rspec (~> 2.14.1)
+  stomp!
+
+BUNDLED WITH
+   1.10.6

--- a/stomp.gemspec
+++ b/stomp.gemspec
@@ -154,12 +154,12 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<rspec>, [">= 2.3"])
+      s.add_development_dependency(%q<rspec>, ["~> 2.14.1"])
     else
-      s.add_dependency(%q<rspec>, [">= 2.3"])
+      s.add_dependency(%q<rspec>, ["~> 2.14.1"])
     end
   else
-    s.add_dependency(%q<rspec>, [">= 2.3"])
+    s.add_dependency(%q<rspec>, ["~> 2.14.1"])
   end
 end
 


### PR DESCRIPTION
Since the test suite cannot run with RSpec 3.x, it would be great to lock down the dependency and add a Gemfile so that it is easier to test with RSpec 2 while also having RSpec 3 installed.