### PR TITLE
Client headers - given hash should not be changed inside Client methods

### DIFF
--- a/lib/client/utils.rb
+++ b/lib/client/utils.rb
@@ -72,10 +72,13 @@ module Stomp
     # setting an id in the SUBSCRIPTION header is described in the stomp protocol docs:
     # http://stomp.github.com/
     def set_subscription_id_if_missing(destination, headers)
-      headers[:id] = headers[:id] ? headers[:id] : headers['id']
-      if headers[:id] == nil
-        headers[:id] = Digest::SHA1.hexdigest(destination)
-      end
+      headers[:id] = build_subscription_id(destination, headers)
+    end
+
+    def build_subscription_id(destination, headers)
+      return headers[:id] until headers[:id].nil?
+      return headers['id'] until headers[:id].nil?
+      Digest::SHA1.hexdigest(destination)
     end
 
     # Parse a stomp URL.

--- a/lib/client/utils.rb
+++ b/lib/client/utils.rb
@@ -77,7 +77,7 @@ module Stomp
 
     def build_subscription_id(destination, headers)
       return headers[:id] until headers[:id].nil?
-      return headers['id'] until headers[:id].nil?
+      return headers['id'] until headers['id'].nil?
       Digest::SHA1.hexdigest(destination)
     end
 

--- a/lib/stomp/client.rb
+++ b/lib/stomp/client.rb
@@ -173,7 +173,7 @@ module Stomp
       # use subscription id to correlate messages to subscription. As described in
       # the SUBSCRIPTION section of the protocol: http://stomp.github.com/.
       # If no subscription id is provided, generate one.
-      set_subscription_id_if_missing(destination, headers)
+      headers = headers.merge(:id => build_subscription_id(destination, headers))
       if @listeners[headers[:id]]
         raise "attempting to subscribe to a queue with a previous subscription"
       end
@@ -183,7 +183,7 @@ module Stomp
 
     # Unsubscribe from a subscription by name.
     def unsubscribe(name, headers = {})
-      set_subscription_id_if_missing(name, headers)
+      headers = headers.merge(:id => build_subscription_id(name, headers))
       @connection.unsubscribe(name, headers)
       @listeners[headers[:id]] = nil
     end
@@ -192,6 +192,7 @@ module Stomp
     # client acknowledgement ( connection.subscribe("/queue/a",{:ack => 'client'}).
     # Accepts a transaction header ( :transaction => 'some_transaction_id' ).
     def ack(message, headers = {})
+      # headers[:a] = 'b'
       txn_id = headers[:transaction]
       if txn_id
         # lets keep around messages ack'd in this transaction in case we rollback
@@ -203,7 +204,7 @@ module Stomp
         replay_list << message
       end
       if block_given?
-        headers['receipt'] = register_receipt_listener lambda {|r| yield r}
+        headers = headers.merge(:receipt => register_receipt_listener(lambda {|r| yield r}))
       end
       context = ack_context_for(message, headers)
       @connection.ack context[:message_id], context[:headers]
@@ -224,7 +225,7 @@ module Stomp
         when Stomp::SPL_12
          'ack'
         when Stomp::SPL_11
-         headers.merge!(:subscription => message.headers['subscription'])
+          headers = headers.merge(:subscription => message.headers['subscription'])
          'message-id'
         else
          'message-id'
@@ -243,7 +244,7 @@ module Stomp
     # Accepts a transaction header ( :transaction => 'some_transaction_id' ).
     def publish(destination, message, headers = {})
       if block_given?
-        headers['receipt'] = register_receipt_listener lambda {|r| yield r}
+        headers = headers.merge(:receipt => register_receipt_listener(lambda {|r| yield r}))
       end
       @connection.publish(destination, message, headers)
     end

--- a/lib/stomp/client.rb
+++ b/lib/stomp/client.rb
@@ -192,7 +192,6 @@ module Stomp
     # client acknowledgement ( connection.subscribe("/queue/a",{:ack => 'client'}).
     # Accepts a transaction header ( :transaction => 'some_transaction_id' ).
     def ack(message, headers = {})
-      # headers[:a] = 'b'
       txn_id = headers[:transaction]
       if txn_id
         # lets keep around messages ack'd in this transaction in case we rollback
@@ -225,7 +224,7 @@ module Stomp
         when Stomp::SPL_12
          'ack'
         when Stomp::SPL_11
-          headers = headers.merge(:subscription => message.headers['subscription'])
+         headers = headers.merge(:subscription => message.headers['subscription'])
          'message-id'
         else
          'message-id'

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -403,7 +403,7 @@ describe Stomp::Client do
     end
   end
 
-  describe 'when custom headers are given' do
+  describe '(used with custom headers)' do
     before :each do
       @client = Stomp::Client.new
     end
@@ -416,9 +416,9 @@ describe Stomp::Client do
     let(:headers) { original_headers }
 
     shared_examples_for 'argument-safe method' do
-      describe 'headers hash' do
+      describe 'given headers hash' do
         subject { headers }
-        it 'has not been changed' do
+        it 'is immutable' do
           is_expected.to match(original_headers)
         end
       end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -402,4 +402,152 @@ describe Stomp::Client do
       end
     end
   end
+
+  describe 'when custom headers are given' do
+    before :each do
+      @client = Stomp::Client.new
+    end
+
+    def original_headers
+      {:custom_header => 'value'}
+    end
+
+    let(:connection_headers) { original_headers }
+    let(:headers) { original_headers }
+
+    shared_examples_for 'argument-safe method' do
+      describe 'headers hash' do
+        subject { headers }
+        it 'has not been changed' do
+          is_expected.to match(original_headers)
+        end
+      end
+    end
+
+    describe '#begin' do
+      before {
+        expect(@mock_connection).to receive(:begin).with('name', connection_headers)
+        @client.begin('name', headers)
+      }
+      it_behaves_like 'argument-safe method'
+    end
+
+    describe '#abort' do
+      before {
+        expect(@mock_connection).to receive(:abort).with('name', connection_headers)
+        @client.abort('name', headers)
+      }
+      it_behaves_like 'argument-safe method'
+    end
+
+    describe '#commit' do
+      before {
+        expect(@mock_connection).to receive(:commit).with('name', connection_headers)
+        @client.commit('name', headers)
+      }
+      it_behaves_like 'argument-safe method'
+    end
+
+    describe '#subscribe' do
+      let(:connection_headers) { original_headers.merge({:id => Digest::SHA1.hexdigest('destination')}) }
+      before {
+        expect(@mock_connection).to receive(:subscribe).with('destination', connection_headers)
+        @client.subscribe('destination', headers) {|dummy_subscriber| }
+      }
+      it_behaves_like 'argument-safe method'
+    end
+
+    describe '#unsubscribe' do
+      let(:connection_headers) { original_headers.merge({:id => Digest::SHA1.hexdigest('destination')}) }
+      before {
+        expect(@mock_connection).to receive(:unsubscribe).with('destination', connection_headers)
+        @client.unsubscribe('destination', headers) {|dummy_subscriber| }
+      }
+      it_behaves_like 'argument-safe method'
+    end
+
+    describe '#ack' do
+      describe 'with STOMP 1.0' do
+        let(:message) { double('message', :headers => {'message-id' => 'id'}) }
+        before {
+          allow(@client).to receive(:protocol).and_return(Stomp::SPL_10)
+          expect(@mock_connection).to receive(:ack).with('id', connection_headers)
+          @client.ack(message, headers)
+        }
+        it_behaves_like 'argument-safe method'
+      end
+      describe 'with STOMP 1.1' do
+        let(:message) { double('message', :headers => {'message-id' => 'id', 'subscription' => 'subscription_name'}) }
+        let(:connection_headers) { original_headers.merge({:subscription => 'subscription_name'}) }
+        before {
+          allow(@client).to receive(:protocol).and_return(Stomp::SPL_11)
+          expect(@mock_connection).to receive(:ack).with('id', connection_headers)
+          @client.ack(message, headers)
+        }
+        it_behaves_like 'argument-safe method'
+      end
+      describe 'with STOMP 1.2' do
+        let(:message) { double('message', :headers => {'ack' => 'id'}) }
+        before {
+          allow(@client).to receive(:protocol).and_return(Stomp::SPL_12)
+          expect(@mock_connection).to receive(:ack).with('id', connection_headers)
+          @client.ack(message, headers)
+        }
+        it_behaves_like 'argument-safe method'
+      end
+    end
+
+    describe '#nack' do
+      describe 'with STOMP 1.0' do
+        let(:message) { double('message', :headers => {'message-id' => 'id'}) }
+        before {
+          allow(@client).to receive(:protocol).and_return(Stomp::SPL_10)
+          expect(@mock_connection).to receive(:nack).with('id', connection_headers)
+          @client.nack(message, headers)
+        }
+        it_behaves_like 'argument-safe method'
+      end
+      describe 'with STOMP 1.1' do
+        let(:message) { double('message', :headers => {'message-id' => 'id', 'subscription' => 'subscription_name'}) }
+        let(:connection_headers) { original_headers.merge({:subscription => 'subscription_name'}) }
+        before {
+          allow(@client).to receive(:protocol).and_return(Stomp::SPL_11)
+          expect(@mock_connection).to receive(:nack).with('id', connection_headers)
+          @client.nack(message, headers)
+        }
+        it_behaves_like 'argument-safe method'
+      end
+      describe 'with STOMP 1.2' do
+        let(:message) { double('message', :headers => {'ack' => 'id'}) }
+        before {
+          allow(@client).to receive(:protocol).and_return(Stomp::SPL_12)
+          expect(@mock_connection).to receive(:nack).with('id', connection_headers)
+          @client.nack(message, headers)
+        }
+        it_behaves_like 'argument-safe method'
+      end
+    end
+
+    describe '#publish' do
+      describe 'without listener' do
+        let(:message) { double('message') }
+        before {
+          expect(@mock_connection).to receive(:publish).with('destination', message, connection_headers)
+          @client.publish('destination', message, headers)
+        }
+        it_behaves_like 'argument-safe method'
+      end
+      describe 'with listener' do
+        let(:message) { double('message') }
+        let(:connection_headers) { original_headers.merge({:receipt => 'receipt-uuid'}) }
+        before {
+          allow(@client).to receive(:uuid).and_return('receipt-uuid')
+          expect(@mock_connection).to receive(:publish).with('destination', message, connection_headers)
+          @client.publish('destination', message, headers) {|dummy_listener| }
+        }
+        it_behaves_like 'argument-safe method'
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
PR for #125 
I covered all client methods with headers has as parameter. So specs cover not only hash immutability but also if headers passed to a connection.
There is also Client#find_listener() method, which modifies message headers, but it's out of this scope. And I'm not sure if it should be changed. 