### PR TITLE
Fix a memory leak in receipt implementation

### DIFF
--- a/lib/client/utils.rb
+++ b/lib/client/utils.rb
@@ -159,7 +159,10 @@ module Stomp
 
     def find_receipt_listener(message)
       listener = @receipt_listeners[message.headers['receipt-id']]
-      listener.call(message) if listener
+      if listener
+         listener.call(message)
+         @receipt_listeners.delete(message.headers['receipt-id'])
+      end
     end
 
     def create_listener_maps

--- a/lib/stomp/client.rb
+++ b/lib/stomp/client.rb
@@ -118,6 +118,7 @@ module Stomp
                         Stomp::Error::BrokerException.new(error)
                     end
 
+        @receipt_listeners.delete(error.headers['receipt-id']) if error.headers['receipt-id']
         client_thread.raise exception
       end
     end


### PR DESCRIPTION
When using a block with Client.publish to receive receipts, we found out a memory leak. Receipt's ID are store in an instance hash but never freed.

Jean Giovinazzo and Alexandre Moutot
Alphalink Developpment