### PR TITLE
Remove self-dependency on stomp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'rake', '~> 0.8.2'

--- a/stomp.gemspec
+++ b/stomp.gemspec
@@ -114,25 +114,18 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.3.7}
   s.summary = %q{Ruby client for the Stomp messaging protocol}
 
-  if s.respond_to? :specification_version then
-    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
+  if s.respond_to?(:specification_version)
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<stomp>, [">= 0"])
       s.add_runtime_dependency(%q<rake>, ["~> 0.8.2"])
       s.add_development_dependency(%q<rspec>, [">= 2.14.1"])
-      s.add_development_dependency(%q<rspec>, [">= 2.14.1"])
     else
-      s.add_dependency(%q<stomp>, [">= 0"])
       s.add_dependency(%q<rake>, ["~> 0.8.2"])
-      s.add_dependency(%q<rspec>, [">= 2.14.1"])
       s.add_dependency(%q<rspec>, [">= 2.14.1"])
     end
   else
-    s.add_dependency(%q<stomp>, [">= 0"])
     s.add_dependency(%q<rake>, ["~> 0.8.2"])
-    s.add_dependency(%q<rspec>, [">= 2.14.1"])
     s.add_dependency(%q<rspec>, [">= 2.14.1"])
   end
 end


### PR DESCRIPTION
Currently installing 1.4.2 through 'gem install stomp' or 'bundle install' breaks.
The reason is just that stomp relies on itself on the gemspec, the error
we get is:

```
Your bundle requires gems that depend on each other, creating an
infinite loop. Please remove gem 'stomp' and try again.
```

This change simply removes that dependency that I believe should not be
there, and also removes the double dev dependency on rspec. Rake is
already required in the gemspec so I removed it from the Gemfile.

Notice the current double 'rspec' requirement and the self-requirement of 'stomp' produce warning/errors already:

```
WARNING:  open-ended dependency on stomp (>= 0) is not recommended
  if stomp is semantically versioned, use:
    add_runtime_dependency 'stomp', '~> 0'
WARNING:  open-ended dependency on rspec (>= 2.14.1, development) is not recommended
  if rspec is semantically versioned, use:
    add_development_dependency 'rspec', '~> 2.14', '>= 2.14.1'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    duplicate dependency on rspec (>= 2.14.1, development), (>= 2.14.1) use:
    add_runtime_dependency 'rspec', '>= 2.14.1', '>= 2.14.1'`
```