### PR TITLE
rspec migrate from deprecated is_expected.to -> expect

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -419,7 +419,7 @@ describe Stomp::Client do
       describe 'given headers hash' do
         subject { headers }
         it 'is immutable' do
-          is_expected.to match(original_headers)
+          expect match(original_headers)
         end
       end
     end


### PR DESCRIPTION
Resolves these errors:

```
  1) Stomp::Client (used with custom headers) #begin behaves like argument-safe method given headers hash is immutable
     Failure/Error: is_expected.to match(original_headers)
     NameError:
       undefined local variable or method `is_expected' for #<RSpec::Core::ExampleGroup::Nested_1::Nested_14::Nested_1::Nested_1::Nested_1:0x0055b53e4ab778>
       Did you mean?  expect
     Shared Example Group: "argument-safe method" called from ./spec/client_spec.rb:432
     # ./spec/client_spec.rb:422:in `block (5 levels) in <top (required)>'
```

With these rspec 2 versions.

rubygem-rspec2-core-2.14.8-7.fc24.noarch
rubygem-rspec2-mocks-2.14.6-5.fc24.1.noarch
rubygem-rspec2-2.14.1-5.fc24.noarch
rubygem-rspec2-expectations-2.14.5-8.fc24.1.noarch