### PR TITLE
Ensure IO#gets exits in a reasonable time

### DIFF
--- a/lib/connection/heartbeats.rb
+++ b/lib/connection/heartbeats.rb
@@ -235,9 +235,9 @@ module Stomp
             # Retry on max lock fails.  Different logic in order to avoid a deadlock.
             if (@max_hbrlck_fails > 0 && lock_fail_count >= @max_hbrlck_fails)
               # This is an attempt at a connection retry.
-              begin
-                @socket.close # Attempt a forced close
-              rescue
+              @gets_semaphore.synchronize do
+                @getst.raise(Errno::EBADF.new) if @getst # kill the socket reading thread if exists
+                @socket.close rescue nil # Attempt a forced close
               end
               @st.kill if @st   # Kill the sender thread if one exists
               Thread.exit       # This receiver thread is done

--- a/lib/stomp/connection.rb
+++ b/lib/stomp/connection.rb
@@ -156,6 +156,7 @@ module Stomp
       @transmit_semaphore = Mutex.new
       @read_semaphore = Mutex.new
       @socket_semaphore = Mutex.new
+      @gets_semaphore = Mutex.new
 
       @subscriptions = {}
       @failure = nil


### PR DESCRIPTION
According to the notes on heartbeats, `max_hbrlck_fails` should be
enabled in order to determine when heartbeats stop arriving. This is
required because the receive thread of the MCO daemon spends most of its
time waiting for something to come in over the wire. That ties up the
"read lock" used to provide exclusive access to the underlying network
socket.

However, the blocking receive should consume heartbeats and update the
"last received" timestamp (`@lr`). The heartbeat read thread also
consumes pings coming in over the wire in case the process is not
blocking on receive.

Normal operation means that a missed hbrlck is normal, but two in a row
should be abnormal (the heartbeat thread may try to read and get locked,
but the receive thread should read the heartbeat before the heartbeat
thread resumes - networking timing could impact this in bad ways - and
reset the "last received" timestamp which will trigger resetting the
`read_lock_count` and `lock_fail_count` the next time the heartbeat
thread wakes).

When the `lock_fail_count` exceeds `@max_hbrlck_fails`, the heartbeat
thread closes the socket and kills the heartbeat threads. The
expectation is that this should cause the `IO#gets` call in the receive
call to return. That doesn't happen until TCP timeouts occur, which can
take minutes or hours. When the TCP timeout occurs, it appears to leave
the main thread in an unexpected state that sometimes results in SIGABRT
and is unreachable via the broker.

To exit `gets` early, trigger an exception in the `receive` thread.
That interrupts the `gets` call and is caught in the `transmit` or
`__old_receive` method and initiates a reconnect.