### PR TITLE
Suppress the exception stack trace that is being raised to stdout

### DIFF
--- a/lib/connection/netio.rb
+++ b/lib/connection/netio.rb
@@ -493,8 +493,8 @@ module Stomp
             ssl.close
           end
           #
-          puts ex.backtrace
-          $stdout.flush
+          puts ex.backtrace if ossdbg
+          $stdout.flush if ossdbg
           raise # Reraise
         end
       end


### PR DESCRIPTION
Solves #161 

Suppress the exception stack trace that is being raised to stdout.
Keep the option to still display the stack trace in case the env variable OSSDBG is set to true.